### PR TITLE
Add version of ww3 for drag coeff in Med Sea

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [ww3dev]
-tag = dev_unified_0.0.5_cm3_00
+tag = dev_unified_0.0.5_cm3_01
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/WW3
 local_path = WW3


### PR DESCRIPTION
Update the External.cfg to contain the new version of the ww3 code.
This ww3 version has some changes for the drag coefficient based on tests done in the Med Sea region.